### PR TITLE
Add option for authentication

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const puppeteer = require('puppeteer');
 
-const go = (url, func, options, auth=null) => {
+const go = (url, func, options, auth) => {
   return puppeteer.launch(options).then(async browser => {
     const page = await browser.newPage();
 

--- a/index.js
+++ b/index.js
@@ -1,8 +1,16 @@
 const puppeteer = require('puppeteer');
 
-const go = (url, func, options) => {
+const go = (url, func, options, auth=null) => {
   return puppeteer.launch(options).then(async browser => {
     const page = await browser.newPage();
+
+    if (auth && auth.username && auth.password) {
+      await page.authenticate({
+        username: auth.username,
+        password: auth.password,
+      })
+    }
+
     await page.goto(url, { waitUntil: 'networkidle2' });
     const data = await func(page, browser);
     await browser.close();


### PR DESCRIPTION
Hi Paul,

I would like to the add the feature of providing authentication to the package in case an user wants to use a proxy. I was using the package and thought it would a good addition to it. 

    if (auth && auth.username && auth.password) {
      await page.authenticate({
        username: auth.username,
        password: auth.password,
      })
    }

This is the code, I have added. If the user passes an auth in parameter, then they will be able to authenticate the proxy creds.

Hope you like it. Thanks.